### PR TITLE
Handle Django 4.0

### DIFF
--- a/django_pwned_passwords/password_validation.py
+++ b/django_pwned_passwords/password_validation.py
@@ -1,6 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.conf import settings
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 import hashlib
 import requests


### PR DESCRIPTION
- change the use of 'django.utils.translation.ugettext' to 'django.utils.translation.gettext'